### PR TITLE
Fixed new service typos

### DIFF
--- a/public/friendService.js
+++ b/public/friendService.js
@@ -2,12 +2,12 @@ angular.module('userProfiles')
 .service('friendService', function( $http ) {
   
     
-    this.login: function( user ) {
+    this.login = function( user ) {
       /* FIX ME */
-    },
+    };
 
-    this.getFriends: function() {
+    this.getFriends = function() {
     	/* FIX ME */
-    }
+    };
   
 });


### PR DESCRIPTION
File had a mix of factory/service syntax from previous commit. Clean up typos for service so that students can focus on just the /\* FIX ME */ portions.
